### PR TITLE
Remove explicit dependency on torch and numpy for dltype

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -27,8 +27,9 @@ jobs:
         run: uv sync --locked --all-extras --dev
 
       - name: Run tests
-        # For example, using `pytest`
-        run: uv run pytest
+        run: |
+          uv run pytest
+          uv run benchmark.py
 
       - name: Build package distributions
         run: uv build

--- a/dltype/__init__.py
+++ b/dltype/__init__.py
@@ -30,7 +30,6 @@ from dltype._lib._dependency_utilities import (
 )
 
 if is_torch_available() and is_numpy_available():
-    print("BOTH TORCH AND NUMPY ARE AVAILABLE")
     from dltype._lib._universal_tensors import (
         IntTensor,
         FloatTensor,
@@ -38,7 +37,6 @@ if is_torch_available() and is_numpy_available():
         DoubleTensor,
     )
 elif is_numpy_available():
-    print("ONLY NUMPY IS AVAILABLE")
     from dltype._lib._numpy_tensors import (
         IntTensor,
         FloatTensor,
@@ -46,7 +44,6 @@ elif is_numpy_available():
         DoubleTensor,
     )
 elif is_torch_available():
-    print("ONLY TORCH IS AVAILABLE")
     from dltype._lib._torch_tensors import (
         IntTensor,
         FloatTensor,

--- a/dltype/__init__.py
+++ b/dltype/__init__.py
@@ -1,23 +1,61 @@
 from dltype._lib._core import (
+    DLTypeScopeProvider,
+    dltyped,
+    dltyped_namedtuple,
+    dltyped_dataclass,
+)
+
+from dltype._lib._constants import (
     DEBUG_MODE,
     MAX_ACCEPTABLE_EVALUATION_TIME_NS,
+)
+
+from dltype._lib._tensor_type_base import (
     SUPPORTED_TENSOR_TYPES,
+    TensorTypeBase,
+)
+
+from dltype._lib._errors import (
     DLTypeError,
-    DLTypeScopeProvider,
     DLTypeShapeError,
     DLTypeScopeProviderError,
     DLTypeInvalidReferenceError,
     DLTypeDuplicateError,
     DLTypeDtypeError,
-    TensorTypeBase,
-    dltyped,
-    dltyped_namedtuple,
-    dltyped_dataclass,
-    IntTensor,
-    FloatTensor,
-    BoolTensor,
-    DoubleTensor,
 )
+from dltype._lib._dependency_utilities import (
+    is_torch_available,
+    is_numpy_available,
+    raise_for_missing_dependency,
+)
+
+if is_torch_available() and is_numpy_available():
+    print("BOTH TORCH AND NUMPY ARE AVAILABLE")
+    from dltype._lib._universal_tensors import (
+        IntTensor,
+        FloatTensor,
+        BoolTensor,
+        DoubleTensor,
+    )
+elif is_numpy_available():
+    print("ONLY NUMPY IS AVAILABLE")
+    from dltype._lib._numpy_tensors import (
+        IntTensor,
+        FloatTensor,
+        BoolTensor,
+        DoubleTensor,
+    )
+elif is_torch_available():
+    print("ONLY TORCH IS AVAILABLE")
+    from dltype._lib._torch_tensors import (
+        IntTensor,
+        FloatTensor,
+        BoolTensor,
+        DoubleTensor,
+    )
+else:
+    raise_for_missing_dependency()
+
 
 __all__ = [
     "DEBUG_MODE",

--- a/dltype/_lib/_constants.py
+++ b/dltype/_lib/_constants.py
@@ -1,0 +1,9 @@
+"""Constants related to the dltype library."""
+
+import typing
+
+
+# Constants
+PYDANTIC_INFO_KEY: typing.Final = "__dltype__"
+DEBUG_MODE: typing.Final = False
+MAX_ACCEPTABLE_EVALUATION_TIME_NS: typing.Final = int(5e9)  # 5ms

--- a/dltype/_lib/_core.py
+++ b/dltype/_lib/_core.py
@@ -4,21 +4,17 @@ from __future__ import annotations
 
 import inspect
 import logging
-import time
 import warnings
-from collections import deque
 from functools import wraps
 from typing import (
     TYPE_CHECKING,
     Annotated,
     Any,
-    ClassVar,
     Final,
     Literal,
     NamedTuple,
     ParamSpec,
     Protocol,
-    TypeAlias,
     TypeVar,
     Union,  # pyright: ignore[reportDeprecated] # TODO(DX-2313): Address pyright errors ignored to migrate from mypy # fmt: skip
     cast,
@@ -28,70 +24,30 @@ from typing import (
     runtime_checkable,
 )
 
-import numpy as np
-import numpy.typing as npt
-import torch
-from pydantic_core import core_schema
-from typing_extensions import override
 
-from dltype._lib._parser import (
-    DLTypeDimensionExpression,
-    DLTypeModifier,
-    expression_from_string,
+from dltype._lib import (
+    _constants,
+    _tensor_type_base,
+    _dltype_context,
+    _errors,
+    _dependency_utilities,
 )
 
 if TYPE_CHECKING:
     from collections.abc import Callable
 
-    from pydantic import GetCoreSchemaHandler, ValidationInfo
 
 _logger: Final = logging.getLogger(__name__)
 
 P = ParamSpec("P")
 R = TypeVar("R")
 
-# Constants
-PYDANTIC_INFO_KEY: Final = "__dltype__"
-EvaluatedDimensionT: TypeAlias = dict[str, int]
-DEBUG_MODE: Final = False
-MAX_ACCEPTABLE_EVALUATION_TIME_NS: Final = int(5e9)  # 5ms
-DLtypeTensorT: TypeAlias = torch.Tensor | npt.NDArray[Any]
-SUPPORTED_TENSOR_TYPES: Final = {torch.Tensor, np.ndarray}
-
-
-def _maybe_warn_runtime(runtime_ns: int) -> None:
-    return runtime_ns > MAX_ACCEPTABLE_EVALUATION_TIME_NS
-
-
-class DLTypeError(TypeError):
-    """An error raised when a type assertion is hit."""
-
-
-class DLTypeShapeError(DLTypeError):
-    """An error raised when a shape assertion is hit."""
-
-
-class DLTypeDtypeError(DLTypeError):
-    """An error raised when a dtype assertion is hit."""
-
-
-class DLTypeDuplicateError(DLTypeError):
-    """An error raised when a duplicate tensor name is hit."""
-
-
-class DLTypeInvalidReferenceError(DLTypeError):
-    """An error raised when an invalid reference is hit."""
-
-
-class DLTypeScopeProviderError(DLTypeError):
-    """An error raised when an invalid scope provider is hit."""
-
 
 class _DLTypeAnnotation(NamedTuple):
     """A class representing a type annotation for a tensor."""
 
-    tensor_type_hint: type[DLtypeTensorT]
-    dltype_annotation: TensorTypeBase
+    tensor_type_hint: type[_tensor_type_base.DLtypeTensorT]
+    dltype_annotation: _tensor_type_base.TensorTypeBase
 
     @classmethod
     def from_hint(
@@ -124,7 +80,9 @@ class _DLTypeAnnotation(NamedTuple):
             return None
 
         # Ensure the annotation is a TensorTypeBase
-        if len(args) < n_expected_args or not isinstance(args[1], TensorTypeBase):
+        if len(args) < n_expected_args or not isinstance(
+            args[1], _tensor_type_base.TensorTypeBase
+        ):
             _logger.warning(
                 "Invalid annotated dltype hint: %r",
                 args[1:] if len(args) >= n_expected_args else None,
@@ -133,411 +91,23 @@ class _DLTypeAnnotation(NamedTuple):
 
         # Ensure the base type is a supported tensor type
         tensor_type, dltype_hint = args[0], args[1]
-        if not any(T in tensor_type.mro() for T in SUPPORTED_TENSOR_TYPES):
-            msg = f"Invalid base type=<{tensor_type}> in DLType hint, expected a subtype of {SUPPORTED_TENSOR_TYPES}"
+        if not any(
+            T in tensor_type.mro() for T in _tensor_type_base.SUPPORTED_TENSOR_TYPES
+        ):
+            msg = f"Invalid base type=<{tensor_type}> in DLType hint, expected a subtype of {_tensor_type_base.SUPPORTED_TENSOR_TYPES}"
             raise TypeError(msg)
 
         dltype_hint.optional = optional
         return cls(tensor_type_hint=tensor_type, dltype_annotation=dltype_hint)
 
 
-class _ConcreteType(NamedTuple):
-    """A class containing a tensor name, a tensor value, and its type."""
-
-    tensor_arg_name: str
-    tensor: DLtypeTensorT
-    dltype_annotation: TensorTypeBase
-
-    def get_expected_shape(
-        self, tensor: DLtypeTensorT
-    ) -> tuple[DLTypeDimensionExpression, ...]:
-        """Get the expected shape of the tensor.
-
-        We handle multi-axis dimensions by replacing the multi-axis placeholder with the actual shape.
-        """
-        expected_shape = list(self.dltype_annotation.expected_shape)
-
-        if self.dltype_annotation.multiaxis_index is not None:
-            _logger.debug(
-                "Replacing multiaxis dimension %r with actual shape %r",
-                self.dltype_annotation.multiaxis_index,
-                tensor.shape,
-            )
-            # for multiaxis dimensions, we replace the values in the expected shape with the actual shape for every
-            # dimension that is not the multiaxis dimension
-            actual_shape = tensor.shape
-
-            multi_axis_offset = len(actual_shape) - len(expected_shape) + 1
-
-            expected_shape.pop(self.dltype_annotation.multiaxis_index)
-            for i in range(multi_axis_offset):
-                expected_shape.insert(
-                    self.dltype_annotation.multiaxis_index + i,
-                    DLTypeDimensionExpression.from_multiaxis_literal(
-                        f"{self.dltype_annotation.multiaxis_name}[{i}]",
-                        actual_shape[self.dltype_annotation.multiaxis_index + i],
-                        is_anonymous=self.dltype_annotation.anonymous_multiaxis,
-                    ),
-                )
-
-        return tuple(expected_shape)
-
-
 @runtime_checkable
 class DLTypeScopeProvider(Protocol):
     """A protocol for classes that provide a scope for DLTypeDimensionExpression evaluation."""
 
-    def get_dltype_scope(self) -> EvaluatedDimensionT:
+    def get_dltype_scope(self) -> _dltype_context.EvaluatedDimensionT:
         """Get the current scope of variables for the DLTypeDimensionExpression evaluation."""
         ...
-
-
-class _DLTypeContext:
-    """A class representing the current context for type hints.
-
-    Keeps track of a simple mapping of names to expected shapes and types.
-
-    This context can be evaluated at any time to check if the current actual shapes and types match the expected ones.
-
-    We evaluate in a first-come-first-correct manner where the first tensor of a given name is considered the correct one.
-    """
-
-    def __init__(self) -> None:
-        """Create a new DLTypeContext."""
-        self._hinted_tensors: deque[_ConcreteType] = deque()
-        # mapping of dimension -> shape
-        self.tensor_shape_map: EvaluatedDimensionT = {}
-        # mapping of tensor name -> tensor type, used to check for duplicates
-        self.registered_tensor_dtypes: dict[str, torch.dtype | npt.DTypeLike] = {}
-
-    def add(self, name: str, tensor: Any, dltype_annotation: TensorTypeBase) -> None:  # noqa: ANN401
-        """Add a tensor to the context."""
-        if dltype_annotation.optional and tensor is None:
-            # skip optional tensors
-            return
-        if not isinstance(tensor, torch.Tensor | np.ndarray):
-            msg = f"Invalid type {type(tensor)}"
-            raise DLTypeError(msg)
-        self._hinted_tensors.append(_ConcreteType(name, tensor, dltype_annotation))
-
-    def assert_context(self) -> None:
-        """Considering the current context, check if all tensors match their expected types."""
-        __tracebackhide__ = not DEBUG_MODE
-
-        start_t = time.perf_counter_ns()
-
-        try:
-            while self._hinted_tensors:
-                tensor_context = self._hinted_tensors.popleft()
-                # first check if the tensor could possibly have the right shape
-                tensor_context.dltype_annotation.check(tensor_context.tensor)
-
-                if tensor_context.tensor_arg_name in self.registered_tensor_dtypes:
-                    msg = f"[tensor={tensor_context.tensor_arg_name=}] Duplicate tensor name in type checking context!"
-                    raise DLTypeDuplicateError(msg)
-
-                self.registered_tensor_dtypes[tensor_context.tensor_arg_name] = (
-                    tensor_context.tensor.dtype
-                )
-                expected_shape = tensor_context.get_expected_shape(
-                    tensor_context.tensor
-                )
-                self._assert_tensor_shape(
-                    tensor_context.tensor_arg_name,
-                    expected_shape,
-                    tensor_context.tensor,
-                )
-
-        finally:
-            end_t = time.perf_counter_ns()
-            runtime_ns = end_t - start_t
-            _logger.debug("Context evaluation took %d ns", runtime_ns)
-            if _maybe_warn_runtime(runtime_ns):
-                warnings.warn(
-                    f"Type checking took longer than expected {(runtime_ns) / 1e6:.2f}ms > {MAX_ACCEPTABLE_EVALUATION_TIME_NS / 1e6}ms",
-                    UserWarning,
-                    stacklevel=2,
-                )
-
-    def _assert_tensor_shape(
-        self,
-        tensor_arg_name: str,
-        expected_shape: tuple[DLTypeDimensionExpression, ...],
-        tensor: DLtypeTensorT,
-    ) -> None:
-        """Check if the tensor shape matches the expected shape."""
-        __tracebackhide__ = not DEBUG_MODE
-        actual_shape = tuple(tensor.shape)
-
-        for dim_idx, dimension_expression in enumerate(expected_shape):
-            if dimension_expression.is_anonymous:
-                # we don't need to check anonymous dimensions
-                continue
-
-            if (
-                dimension_expression.is_literal
-                and dimension_expression.identifier not in self.tensor_shape_map
-            ):
-                # handled by the check method above
-                _logger.debug(
-                    "Skipping literal dimension %r (%s)",
-                    dimension_expression,
-                    self.tensor_shape_map,
-                )
-                continue
-
-            if (
-                dimension_expression.is_identifier
-                and dimension_expression.identifier not in self.tensor_shape_map
-            ):
-                _logger.debug(
-                    "establishing %r with %r",
-                    dimension_expression.identifier,
-                    actual_shape[dim_idx],
-                )
-                self.tensor_shape_map[dimension_expression.identifier] = actual_shape[
-                    dim_idx
-                ]
-                continue
-
-            _logger.debug(
-                "Checking dimension %r with scope=%s",
-                dimension_expression,
-                self.tensor_shape_map,
-            )
-
-            try:
-                expected_result = dimension_expression.evaluate(self.tensor_shape_map)
-            except KeyError as e:
-                missing_ref = e.args[0]
-                msg = f"[tensor={tensor_arg_name}] Missing reference '{missing_ref}' in {self.tensor_shape_map=}"
-                raise DLTypeInvalidReferenceError(msg) from e
-
-            if expected_result != actual_shape[dim_idx]:
-                msg = f"[tensor={tensor_arg_name}] Invalid shape at {dim_idx=} actual={actual_shape[dim_idx]} expected {dimension_expression}={expected_result}"
-                raise DLTypeShapeError(msg)
-
-            if dimension_expression.identifier not in self.tensor_shape_map:
-                self.tensor_shape_map[dimension_expression.identifier] = actual_shape[
-                    dim_idx
-                ]
-
-
-def _resolve_numpy_dtype(np_array_t: type[npt.NDArray[Any]]) -> list[npt.DTypeLike]:
-    """Resolve the numpy dtype of a numpy array."""
-    maybe_dtype_arg = get_args(np_array_t)[1]
-    maybe_dtype = get_args(maybe_dtype_arg)
-
-    # if the dtype is a union of types, we need to resolve it
-    return [
-        cast("npt.DTypeLike", dtype)
-        for maybe_union in maybe_dtype
-        for dtype in get_args(maybe_union) or [maybe_union]
-    ]
-
-
-class TensorTypeBase:
-    """A class to represent a tensor type.
-
-    A tensor type is expected to validate the shape of any literal integers present in the type hint.
-    It may also choose to validate the datatype of the tensor.
-    """
-
-    TORCH_DTYPES: ClassVar[tuple[torch.dtype, ...]] = ()
-    """The torch dtypes that this tensor type asserts to contain. (empty for any dtype)."""
-    NP_DTYPES: ClassVar[tuple[npt.DTypeLike, ...]] = ()
-    """The numpy dtypes that this tensor type asserts to contain. (empty for any dtype)."""
-
-    def __init__(self, shape: str | None, optional: bool = False) -> None:
-        """Create a new tensor type object."""
-        self.multiaxis_index: int | None = None
-        self.anonymous_multiaxis: bool = False
-        self.multiaxis_name: str | None = None
-        self.optional = optional
-        self.expected_shape = self._parse_shape_string(shape)
-        # only include literal dimensions that aren't multiaxis
-        self._literal_dims = tuple(
-            (idx, dim.evaluate({}))
-            for idx, dim in enumerate(self.expected_shape)
-            if dim.is_literal and idx != self.multiaxis_index  # pyright: ignore[reportUnnecessaryComparison] # TODO(DX-2313): Address pyright errors ignored to migrate from mypy # fmt: skip
-        )
-
-    @override
-    def __repr__(self) -> str:
-        """Get the string representation of the tensor type."""
-        return f"{self.__class__.__name__}[{self.expected_shape}]"
-
-    def _parse_shape_string(
-        self, shape_string: str | None
-    ) -> tuple[DLTypeDimensionExpression, ...]:
-        """Parse the shape string into a list of dimension expressions."""
-        if shape_string is None:
-            return ()
-
-        split_shape = shape_string.split()
-
-        if not split_shape:
-            msg = f"Invalid shape {shape_string=}"
-            raise SyntaxError(msg)
-
-        # Process shape specification, looking for multiaxis modifiers
-        processed_shapes: list[DLTypeDimensionExpression] = []
-        modifiers: dict[int, DLTypeModifier | None] = {}
-
-        for i, dim_str in enumerate(split_shape):
-            modifiers[i] = None
-            for modifier in DLTypeModifier:
-                if dim_str.startswith(modifier.value):
-                    modifiers[i] = modifier
-                    break
-
-            this_dimension_modifier = modifiers[i]
-            if this_dimension_modifier in {
-                DLTypeModifier.NAMED_MULTIAXIS,
-                DLTypeModifier.ANONYMOUS_MULTIAXIS,
-            }:
-                if self.multiaxis_index is not None:
-                    msg = f"Multiple multiaxis modifiers not allowed in {shape_string=}"
-                    raise SyntaxError(msg)
-
-                self.multiaxis_index = i
-                self.multiaxis_name = dim_str[len(this_dimension_modifier.value) :]
-                self.anonymous_multiaxis = (
-                    this_dimension_modifier == DLTypeModifier.ANONYMOUS_MULTIAXIS
-                )
-
-            processed_shapes.append(expression_from_string(dim_str))
-
-        return tuple(processed_shapes)
-
-    @classmethod
-    def __class_getitem__(cls, shape_string: str) -> TensorTypeBase:
-        """Get the type of the tensor."""
-        return cls(shape_string)
-
-    def __get_pydantic_core_schema__(
-        self, source_type: type, handler: GetCoreSchemaHandler
-    ) -> core_schema.CoreSchema:
-        """Get the Pydantic core schema for this type."""
-
-        def validate_tensor(
-            tensor: DLtypeTensorT, info: ValidationInfo
-        ) -> DLtypeTensorT:
-            """Validate the tensor."""
-            __tracebackhide__ = not DEBUG_MODE
-            self.check(tensor)
-
-            if PYDANTIC_INFO_KEY not in info.data:
-                info.data[PYDANTIC_INFO_KEY] = _DLTypeContext()
-
-            dl_context = cast("_DLTypeContext", info.data[PYDANTIC_INFO_KEY])
-            dl_context.add(info.field_name or "_unknown_", tensor, self)
-            dl_context.assert_context()
-
-            return tensor
-
-        if get_origin(source_type) is np.ndarray:
-            dtypes = _resolve_numpy_dtype(source_type)
-            if self.NP_DTYPES and any(dtype not in self.NP_DTYPES for dtype in dtypes):
-                msg = f"Invalid numpy array dtype=<{dtypes}> expected ({'|'.join(map(str, self.NP_DTYPES))})"
-                raise DLTypeDtypeError(msg)
-            # numpy arrays don't implement isinstance() because the type is actually a
-            # parameterized generic alias and not a concrete type. We need to check the origin instead.
-            # This is a bit of a hack, but we still get the correct type hint in the end because we check against the dtype of the tensor first.
-            source_type = np.ndarray
-
-        return core_schema.with_info_after_validator_function(
-            validate_tensor,
-            schema=core_schema.is_instance_schema(source_type),
-            field_name=handler.field_name,
-        )
-
-    def check(self, tensor: npt.NDArray[Any] | torch.Tensor) -> None:
-        """Check if the tensor matches this type."""
-        # Basic validation for multi-axis dimensions
-        __tracebackhide__ = not DEBUG_MODE
-        if self.multiaxis_index is not None:
-            # Min required dimensions = expected shape length + extra dimensions - 1 (the multi-axis placeholder)
-            min_required_dims = len(self.expected_shape) - 1
-            if len(tensor.shape) < min_required_dims:
-                msg = f"Invalid number of dimensions: {tensor.shape=}, expected at least {min_required_dims}"
-                raise DLTypeShapeError(msg)
-
-        # Standard case: exact dimension count match
-        elif len(tensor.shape) != len(self.expected_shape):
-            msg = f"Invalid number of dimensions {tensor.shape=} {self.expected_shape=}"
-            raise DLTypeShapeError(msg)
-
-        if (
-            isinstance(tensor, torch.Tensor)
-            and self.TORCH_DTYPES
-            and tensor.dtype not in self.TORCH_DTYPES
-        ):
-            msg = f"Invalid dtype {tensor.dtype} expected {self.TORCH_DTYPES}"
-            raise DLTypeDtypeError(msg)
-
-        if (
-            isinstance(tensor, np.ndarray)
-            and self.NP_DTYPES
-            and tensor.dtype not in self.NP_DTYPES
-        ):
-            msg = f"Invalid dtype {tensor.dtype} expected {self.NP_DTYPES}"
-            raise DLTypeDtypeError(msg)
-
-        for idx, dim in self._literal_dims:
-            # Adjust index if multiaxis exists and is before this dimension
-            adjusted_idx = idx
-            if self.multiaxis_index is not None and idx > self.multiaxis_index:
-                # Adjust by the difference between actual and expected dimensions
-                adjusted_idx += len(tensor.shape) - len(self.expected_shape)
-
-            if tensor.shape[adjusted_idx] != dim:
-                msg = f"[tensor=tensor] Invalid shape at dim_idx={adjusted_idx} actual={tensor.shape[adjusted_idx]} expected {dim}"
-                raise DLTypeShapeError(msg)
-
-
-class IntTensor(TensorTypeBase):
-    """A class to represent an integer tensor type."""
-
-    TORCH_DTYPES = (torch.int, torch.int8, torch.int16, torch.int32, torch.int64)
-    NP_DTYPES = (np.int_, np.int8, np.int16, np.int32, np.int64)
-
-
-class FloatTensor(TensorTypeBase):
-    """A class to represent a float tensor type."""
-
-    TORCH_DTYPES = (
-        torch.float,
-        torch.float16,
-        torch.float32,
-        torch.float64,
-        torch.half,
-        torch.bfloat16,
-        torch.double,
-    )
-    NP_DTYPES = (
-        np.float64,
-        np.float16,
-        np.float32,
-        np.float64,
-        np.float128,
-        np.half,
-        np.longdouble,
-    )
-
-
-class BoolTensor(TensorTypeBase):
-    """A class to represent a boolean tensor type."""
-
-    TORCH_DTYPES = (torch.bool,)
-    NP_DTYPES = (np.bool_,)
-
-
-class DoubleTensor(TensorTypeBase):
-    """A class to represent a double tensor type."""
-
-    TORCH_DTYPES = (torch.double,)
-    NP_DTYPES = (np.float64,)
 
 
 def _maybe_get_type_hints(
@@ -581,7 +151,7 @@ def dltyped(  # noqa: C901, PLR0915
     """
 
     def _inner_dltyped(func: Callable[P, R]) -> Callable[P, R]:  # noqa: C901, PLR0915
-        if torch.jit.is_scripting():
+        if _dependency_utilities.is_torch_scripting():
             # jit script doesn't support annotated type hints at all, we have no choice but to skip the type checking
             return func
 
@@ -612,9 +182,9 @@ def dltyped(  # noqa: C901, PLR0915
             return func
 
         @wraps(func)
-        @torch.jit.unused
+        @_dependency_utilities.torch_jit_unused
         def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:  # noqa: C901, PLR0912
-            __tracebackhide__ = not DEBUG_MODE
+            __tracebackhide__ = not _constants.DEBUG_MODE
             nonlocal signature
             nonlocal dltype_hints
 
@@ -633,7 +203,7 @@ def dltyped(  # noqa: C901, PLR0915
 
             _actual_args = bound_args.arguments
 
-            ctx = _DLTypeContext()
+            ctx = _dltype_context.DLTypeContext()
 
             if scope_provider == "self" and isinstance(
                 _actual_args[str(scope_provider)], DLTypeScopeProvider
@@ -649,7 +219,7 @@ def dltyped(  # noqa: C901, PLR0915
                 _logger.debug("Using unbound scope provider %s", ctx.tensor_shape_map)
             elif scope_provider is not None:
                 msg = f"Invalid scope provider {scope_provider=} expected DLTypeScopeProvider or 'self'"
-                raise DLTypeScopeProviderError(msg)
+                raise _errors.DLTypeScopeProviderError(msg)
 
             for name in dltype_hints:
                 if name == _return_key:
@@ -665,7 +235,10 @@ def dltyped(  # noqa: C901, PLR0915
                 if maybe_annotation := dltype_hints.get(name):
                     tensor = _actual_args[name]
                     ctx.add(name, tensor, maybe_annotation.dltype_annotation)
-                elif isinstance(_actual_args[name], torch.Tensor | np.ndarray):
+                elif any(
+                    isinstance(_actual_args[name], T)
+                    for T in _tensor_type_base.SUPPORTED_TENSOR_TYPES
+                ):
                     warnings.warn(
                         f"[argument={name}] is missing a DLType hint",
                         UserWarning,
@@ -682,13 +255,16 @@ def dltyped(  # noqa: C901, PLR0915
                         _return_key, retval, maybe_return_annotation.dltype_annotation
                     )
                     ctx.assert_context()
-                elif isinstance(retval, torch.Tensor | np.ndarray):
+                elif any(
+                    isinstance(retval, T)
+                    for T in _tensor_type_base.SUPPORTED_TENSOR_TYPES
+                ):
                     warnings.warn(
                         f"[{_return_key}] is missing a DLType hint",
                         UserWarning,
                         stacklevel=2,
                     )
-            except DLTypeError as e:
+            except _errors.DLTypeError as e:
                 # include the full function signature in the error message
                 msg = f"Error in {func.__name__}{signature}: {e}\n"
                 raise e.__class__(msg) from e
@@ -741,7 +317,7 @@ def dltyped_namedtuple() -> Callable[[type[NT]], type[NT]]:  # noqa: C901
             instance = original_new(cls_inner, *args, **kwargs)
 
             # Then validate all fields with DLType annotations
-            ctx = _DLTypeContext()
+            ctx = _dltype_context.DLTypeContext()
             for field_name, annotation in dltype_fields.items():
                 field_index = cls._fields.index(field_name)
                 value = instance[field_index]
@@ -751,7 +327,7 @@ def dltyped_namedtuple() -> Callable[[type[NT]], type[NT]]:  # noqa: C901
             # Assert that all fields are valid
             try:
                 ctx.assert_context()
-            except DLTypeError as e:
+            except _errors.DLTypeError as e:
                 msg = f"Error in {cls.__name__} constructor: {e}\n"
                 raise e.__class__(msg) from e
 
@@ -777,7 +353,7 @@ def dltyped_dataclass() -> Callable[[type[DataclassT]], type[DataclassT]]:
     """
 
     def _inner_dltyped_dataclass(cls: type[DataclassT]) -> type[DataclassT]:
-        if torch.jit.is_scripting():
+        if _dependency_utilities.is_torch_scripting():
             return cls
 
         # check that we are a dataclass, raise an error if not
@@ -800,7 +376,7 @@ def dltyped_dataclass() -> Callable[[type[DataclassT]], type[DataclassT]]:
             original_init(self, *args, **kwargs)
 
             # Validate fields with DLType annotations
-            ctx = _DLTypeContext()
+            ctx = _dltype_context.DLTypeContext()
 
             for field_name in field_hints:
                 annotation = _dltype_hints.get(field_name)
@@ -818,7 +394,7 @@ def dltyped_dataclass() -> Callable[[type[DataclassT]], type[DataclassT]]:
             # Assert that all fields are valid
             try:
                 ctx.assert_context()
-            except DLTypeError as e:
+            except _errors.DLTypeError as e:
                 msg = f"Error in {cls.__name__} field validation: {e}"
                 raise e.__class__(msg) from e
 

--- a/dltype/_lib/_dependency_utilities.py
+++ b/dltype/_lib/_dependency_utilities.py
@@ -1,0 +1,59 @@
+"""Utilities to handle optional dependencies in dltype."""
+
+from functools import cache
+from collections.abc import Callable
+from typing import TypeVar, ParamSpec, NoReturn
+
+Ret = TypeVar("Ret")
+P = ParamSpec("P")
+
+
+def _empty_wrapper(fn: Callable[P, Ret]) -> Callable[P, Ret]:
+    """A no-op function used as a placeholder for optional dependencies."""
+    return fn
+
+
+# import these first and avoid runtime penalties if they are not available
+try:
+    import torch
+
+    torch_jit_unused = torch.jit.unused  # re-export for compatibility
+except ImportError:
+    torch_jit_unused = _empty_wrapper
+    torch = None
+
+try:
+    import numpy as np
+except ImportError:
+    np = None
+
+
+@cache
+def is_torch_available() -> bool:
+    """Check if the torch library is available."""
+    return torch is not None
+
+
+@cache
+def is_numpy_available() -> bool:
+    """Check if the numpy library is available."""
+    return np is not None
+
+
+def raise_for_missing_dependency() -> NoReturn:
+    """Raise an ImportError if neither torch nor numpy is available."""
+    if not is_torch_available() and not is_numpy_available():
+        raise ImportError(
+            "Neither torch nor numpy is available. Please install one of them to use dltype."
+        )
+    assert False, (
+        "Improper use of raise_for_missing_dependency, should only be called when both dependencies are missing."
+    )
+
+
+def is_torch_scripting() -> bool:
+    """Check if the torch library is in scripting mode."""
+    if not is_torch_available():
+        return False
+
+    return torch.jit.is_scripting()

--- a/dltype/_lib/_dltype_context.py
+++ b/dltype/_lib/_dltype_context.py
@@ -8,9 +8,6 @@ import warnings
 from collections import deque
 from typing import Any, Final, NamedTuple, TypeAlias
 
-import numpy as np
-import numpy.typing as npt
-import torch
 
 from dltype._lib import _parser, _constants, _tensor_type_base, _errors
 
@@ -82,7 +79,7 @@ class DLTypeContext:
         # mapping of dimension -> shape
         self.tensor_shape_map: EvaluatedDimensionT = {}
         # mapping of tensor name -> tensor type, used to check for duplicates
-        self.registered_tensor_dtypes: dict[str, torch.dtype | npt.DTypeLike] = {}
+        self.registered_tensor_dtypes: dict[str, _tensor_type_base.DLtypeDtypeT] = {}
 
     def add(
         self,
@@ -94,7 +91,9 @@ class DLTypeContext:
         if dltype_annotation.optional and tensor is None:
             # skip optional tensors
             return
-        if not isinstance(tensor, torch.Tensor | np.ndarray):
+        if not any(
+            isinstance(tensor, T) for T in _tensor_type_base.SUPPORTED_TENSOR_TYPES
+        ):
             msg = f"Invalid type {type(tensor)}"
             raise _errors.DLTypeError(msg)
         self._hinted_tensors.append(_ConcreteType(name, tensor, dltype_annotation))

--- a/dltype/_lib/_dltype_context.py
+++ b/dltype/_lib/_dltype_context.py
@@ -1,0 +1,202 @@
+"""A module to assist with using Annotated[torch.Tensor] in type hints."""
+
+from __future__ import annotations
+
+import logging
+import time
+import warnings
+from collections import deque
+from typing import Any, Final, NamedTuple, TypeAlias
+
+import numpy as np
+import numpy.typing as npt
+import torch
+
+from dltype._lib import _parser, _constants, _tensor_type_base, _errors
+
+
+_logger: Final = logging.getLogger(__name__)
+
+EvaluatedDimensionT: TypeAlias = dict[str, int]
+
+
+def _maybe_warn_runtime(runtime_ns: int) -> None:
+    return runtime_ns > _constants.MAX_ACCEPTABLE_EVALUATION_TIME_NS
+
+
+class _ConcreteType(NamedTuple):
+    """A class containing a tensor name, a tensor value, and its type."""
+
+    tensor_arg_name: str
+    tensor: _tensor_type_base.DLtypeTensorT
+    dltype_annotation: _tensor_type_base.TensorTypeBase
+
+    def get_expected_shape(
+        self, tensor: _tensor_type_base.DLtypeTensorT
+    ) -> tuple[_parser.DLTypeDimensionExpression, ...]:
+        """Get the expected shape of the tensor.
+
+        We handle multi-axis dimensions by replacing the multi-axis placeholder with the actual shape.
+        """
+        expected_shape = list(self.dltype_annotation.expected_shape)
+
+        if self.dltype_annotation.multiaxis_index is not None:
+            _logger.debug(
+                "Replacing multiaxis dimension %r with actual shape %r",
+                self.dltype_annotation.multiaxis_index,
+                tensor.shape,
+            )
+            # for multiaxis dimensions, we replace the values in the expected shape with the actual shape for every
+            # dimension that is not the multiaxis dimension
+            actual_shape = tensor.shape
+
+            multi_axis_offset = len(actual_shape) - len(expected_shape) + 1
+
+            expected_shape.pop(self.dltype_annotation.multiaxis_index)
+            for i in range(multi_axis_offset):
+                expected_shape.insert(
+                    self.dltype_annotation.multiaxis_index + i,
+                    _parser.DLTypeDimensionExpression.from_multiaxis_literal(
+                        f"{self.dltype_annotation.multiaxis_name}[{i}]",
+                        actual_shape[self.dltype_annotation.multiaxis_index + i],
+                        is_anonymous=self.dltype_annotation.anonymous_multiaxis,
+                    ),
+                )
+
+        return tuple(expected_shape)
+
+
+class DLTypeContext:
+    """A class representing the current context for type hints.
+
+    Keeps track of a simple mapping of names to expected shapes and types.
+
+    This context can be evaluated at any time to check if the current actual shapes and types match the expected ones.
+
+    We evaluate in a first-come-first-correct manner where the first tensor of a given name is considered the correct one.
+    """
+
+    def __init__(self) -> None:
+        """Create a new DLTypeContext."""
+        self._hinted_tensors: deque[_ConcreteType] = deque()
+        # mapping of dimension -> shape
+        self.tensor_shape_map: EvaluatedDimensionT = {}
+        # mapping of tensor name -> tensor type, used to check for duplicates
+        self.registered_tensor_dtypes: dict[str, torch.dtype | npt.DTypeLike] = {}
+
+    def add(
+        self,
+        name: str,
+        tensor: Any,
+        dltype_annotation: _tensor_type_base.TensorTypeBase,
+    ) -> None:  # noqa: ANN401
+        """Add a tensor to the context."""
+        if dltype_annotation.optional and tensor is None:
+            # skip optional tensors
+            return
+        if not isinstance(tensor, torch.Tensor | np.ndarray):
+            msg = f"Invalid type {type(tensor)}"
+            raise _errors.DLTypeError(msg)
+        self._hinted_tensors.append(_ConcreteType(name, tensor, dltype_annotation))
+
+    def assert_context(self) -> None:
+        """Considering the current context, check if all tensors match their expected types."""
+        __tracebackhide__ = not _constants.DEBUG_MODE
+
+        start_t = time.perf_counter_ns()
+
+        try:
+            while self._hinted_tensors:
+                tensor_context = self._hinted_tensors.popleft()
+                # first check if the tensor could possibly have the right shape
+                tensor_context.dltype_annotation.check(tensor_context.tensor)
+
+                if tensor_context.tensor_arg_name in self.registered_tensor_dtypes:
+                    msg = f"[tensor={tensor_context.tensor_arg_name=}] Duplicate tensor name in type checking context!"
+                    raise _errors.DLTypeDuplicateError(msg)
+
+                self.registered_tensor_dtypes[tensor_context.tensor_arg_name] = (
+                    tensor_context.tensor.dtype
+                )
+                expected_shape = tensor_context.get_expected_shape(
+                    tensor_context.tensor
+                )
+                self._assert_tensor_shape(
+                    tensor_context.tensor_arg_name,
+                    expected_shape,
+                    tensor_context.tensor,
+                )
+
+        finally:
+            end_t = time.perf_counter_ns()
+            runtime_ns = end_t - start_t
+            _logger.debug("Context evaluation took %d ns", runtime_ns)
+            if _maybe_warn_runtime(runtime_ns):
+                warnings.warn(
+                    f"Type checking took longer than expected {(runtime_ns) / 1e6:.2f}ms > {_constants.MAX_ACCEPTABLE_EVALUATION_TIME_NS / 1e6}ms",
+                    UserWarning,
+                    stacklevel=2,
+                )
+
+    def _assert_tensor_shape(
+        self,
+        tensor_arg_name: str,
+        expected_shape: tuple[_parser.DLTypeDimensionExpression, ...],
+        tensor: _tensor_type_base.DLtypeTensorT,
+    ) -> None:
+        """Check if the tensor shape matches the expected shape."""
+        __tracebackhide__ = not _constants.DEBUG_MODE
+        actual_shape = tuple(tensor.shape)
+
+        for dim_idx, dimension_expression in enumerate(expected_shape):
+            if dimension_expression.is_anonymous:
+                # we don't need to check anonymous dimensions
+                continue
+
+            if (
+                dimension_expression.is_literal
+                and dimension_expression.identifier not in self.tensor_shape_map
+            ):
+                # handled by the check method above
+                _logger.debug(
+                    "Skipping literal dimension %r (%s)",
+                    dimension_expression,
+                    self.tensor_shape_map,
+                )
+                continue
+
+            if (
+                dimension_expression.is_identifier
+                and dimension_expression.identifier not in self.tensor_shape_map
+            ):
+                _logger.debug(
+                    "establishing %r with %r",
+                    dimension_expression.identifier,
+                    actual_shape[dim_idx],
+                )
+                self.tensor_shape_map[dimension_expression.identifier] = actual_shape[
+                    dim_idx
+                ]
+                continue
+
+            _logger.debug(
+                "Checking dimension %r with scope=%s",
+                dimension_expression,
+                self.tensor_shape_map,
+            )
+
+            try:
+                expected_result = dimension_expression.evaluate(self.tensor_shape_map)
+            except KeyError as e:
+                missing_ref = e.args[0]
+                msg = f"[tensor={tensor_arg_name}] Missing reference '{missing_ref}' in {self.tensor_shape_map=}"
+                raise _errors.DLTypeInvalidReferenceError(msg) from e
+
+            if expected_result != actual_shape[dim_idx]:
+                msg = f"[tensor={tensor_arg_name}] Invalid shape at {dim_idx=} actual={actual_shape[dim_idx]} expected {dimension_expression}={expected_result}"
+                raise _errors.DLTypeShapeError(msg)
+
+            if dimension_expression.identifier not in self.tensor_shape_map:
+                self.tensor_shape_map[dimension_expression.identifier] = actual_shape[
+                    dim_idx
+                ]

--- a/dltype/_lib/_errors.py
+++ b/dltype/_lib/_errors.py
@@ -1,0 +1,25 @@
+"""Errors for the dltype library."""
+
+
+class DLTypeError(TypeError):
+    """An error raised when a type assertion is hit."""
+
+
+class DLTypeShapeError(DLTypeError):
+    """An error raised when a shape assertion is hit."""
+
+
+class DLTypeDtypeError(DLTypeError):
+    """An error raised when a dtype assertion is hit."""
+
+
+class DLTypeDuplicateError(DLTypeError):
+    """An error raised when a duplicate tensor name is hit."""
+
+
+class DLTypeInvalidReferenceError(DLTypeError):
+    """An error raised when an invalid reference is hit."""
+
+
+class DLTypeScopeProviderError(DLTypeError):
+    """An error raised when an invalid scope provider is hit."""

--- a/dltype/_lib/_numpy_tensors.py
+++ b/dltype/_lib/_numpy_tensors.py
@@ -1,0 +1,37 @@
+"""Numpy-only tensor types for DLType."""
+
+import numpy as np
+
+from dltype._lib._tensor_type_base import TensorTypeBase
+
+
+class IntTensor(TensorTypeBase):
+    """A class to represent an integer tensor type."""
+
+    DTYPES = (np.int_, np.int8, np.int16, np.int32, np.int64)
+
+
+class FloatTensor(TensorTypeBase):
+    """A class to represent a float tensor type."""
+
+    DTYPES = (
+        np.float64,
+        np.float16,
+        np.float32,
+        np.float64,
+        np.float128,
+        np.half,
+        np.longdouble,
+    )
+
+
+class BoolTensor(TensorTypeBase):
+    """A class to represent a boolean tensor type."""
+
+    DTYPES = (np.bool_,)
+
+
+class DoubleTensor(TensorTypeBase):
+    """A class to represent a double tensor type."""
+
+    DTYPES = (np.float64,)

--- a/dltype/_lib/_tensor_type_base.py
+++ b/dltype/_lib/_tensor_type_base.py
@@ -1,0 +1,211 @@
+"""The base class for all dltype supported tensor annotations."""
+
+from __future__ import annotations
+
+import typing
+
+import numpy as np
+import numpy.typing as npt
+import torch
+from pydantic_core import core_schema
+from typing_extensions import override
+
+from dltype._lib import (
+    _parser,
+    _errors,
+    _constants,
+    _dltype_context,
+    _dependency_utilities as _deps,
+)
+
+if typing.TYPE_CHECKING:
+    from pydantic import GetCoreSchemaHandler, ValidationInfo
+
+if _deps.is_numpy_available() and _deps.is_torch_available():
+    import torch
+    import numpy.typing as npt
+
+    DLtypeTensorT: typing.TypeAlias = torch.Tensor | npt.NDArray[typing.Any]
+    DLtypeDtypeT: typing.TypeAlias = torch.dtype | npt.DTypeLike
+    SUPPORTED_TENSOR_TYPES: typing.Final = {torch.Tensor, np.ndarray}
+elif _deps.is_numpy_available():
+    import numpy as np
+    import numpy.typing as npt
+
+    DLtypeTensorT: typing.TypeAlias = npt.NDArray[typing.Any]
+    DLtypeDtypeT: typing.TypeAlias = npt.DTypeLike
+    SUPPORTED_TENSOR_TYPES: typing.Final = {np.ndarray}
+elif _deps.is_torch_available():
+    import torch
+
+    DLtypeTensorT: typing.TypeAlias = torch.Tensor
+    DLtypeDtypeT: typing.TypeAlias = torch.dtype
+    SUPPORTED_TENSOR_TYPES: typing.Final = {torch.Tensor}
+else:
+    _deps.raise_for_missing_dependency()
+
+
+def _resolve_numpy_dtype(
+    np_array_t: type[npt.NDArray[typing.Any]],
+) -> list[npt.DTypeLike]:
+    """Resolve the numpy dtype of a numpy array."""
+    maybe_dtype_arg = typing.get_args(np_array_t)[1]
+    maybe_dtype = typing.get_args(maybe_dtype_arg)
+
+    # if the dtype is a union of types, we need to resolve it
+    return [
+        typing.cast("npt.DTypeLike", dtype)
+        for maybe_union in maybe_dtype
+        for dtype in typing.get_args(maybe_union) or [maybe_union]
+    ]
+
+
+class TensorTypeBase:
+    """A class to represent a tensor type.
+
+    A tensor type is expected to validate the shape of any literal integers present in the type hint.
+    It may also choose to validate the datatype of the tensor.
+    """
+
+    DTYPES: typing.ClassVar[tuple[DLtypeDtypeT, ...]] = ()
+    """The torch dtypes that this tensor type asserts to contain. (empty for any dtype)."""
+
+    def __init__(self, shape: str | None, optional: bool = False) -> None:
+        """Create a new tensor type object."""
+        self.multiaxis_index: int | None = None
+        self.anonymous_multiaxis: bool = False
+        self.multiaxis_name: str | None = None
+        self.optional = optional
+        self.expected_shape = self._parse_shape_string(shape)
+        # only include literal dimensions that aren't multiaxis
+        self._literal_dims = tuple(
+            (idx, dim.evaluate({}))
+            for idx, dim in enumerate(self.expected_shape)
+            if dim.is_literal and idx != self.multiaxis_index  # pyright: ignore[reportUnnecessaryComparison] # TODO(DX-2313): Address pyright errors ignored to migrate from mypy # fmt: skip
+        )
+
+    @override
+    def __repr__(self) -> str:
+        """Get the string representation of the tensor type."""
+        return f"{self.__class__.__name__}[{self.expected_shape}]"
+
+    def _parse_shape_string(
+        self, shape_string: str | None
+    ) -> tuple[_parser.DLTypeDimensionExpression, ...]:
+        """Parse the shape string into a list of dimension expressions."""
+        if shape_string is None:
+            return ()
+
+        split_shape = shape_string.split()
+
+        if not split_shape:
+            msg = f"Invalid shape {shape_string=}"
+            raise SyntaxError(msg)
+
+        # Process shape specification, looking for multiaxis modifiers
+        processed_shapes: list[_parser.DLTypeDimensionExpression] = []
+        modifiers: dict[int, _parser.DLTypeModifier | None] = {}
+
+        for i, dim_str in enumerate(split_shape):
+            modifiers[i] = None
+            for modifier in _parser.DLTypeModifier:
+                if dim_str.startswith(modifier.value):
+                    modifiers[i] = modifier
+                    break
+
+            this_dimension_modifier = modifiers[i]
+            if this_dimension_modifier in {
+                _parser.DLTypeModifier.NAMED_MULTIAXIS,
+                _parser.DLTypeModifier.ANONYMOUS_MULTIAXIS,
+            }:
+                if self.multiaxis_index is not None:
+                    msg = f"Multiple multiaxis modifiers not allowed in {shape_string=}"
+                    raise SyntaxError(msg)
+
+                self.multiaxis_index = i
+                self.multiaxis_name = dim_str[len(this_dimension_modifier.value) :]
+                self.anonymous_multiaxis = (
+                    this_dimension_modifier
+                    == _parser.DLTypeModifier.ANONYMOUS_MULTIAXIS
+                )
+
+            processed_shapes.append(_parser.expression_from_string(dim_str))
+
+        return tuple(processed_shapes)
+
+    @classmethod
+    def __class_getitem__(cls, shape_string: str) -> TensorTypeBase:
+        """Get the type of the tensor."""
+        return cls(shape_string)
+
+    def __get_pydantic_core_schema__(
+        self, source_type: type, handler: GetCoreSchemaHandler
+    ) -> core_schema.CoreSchema:
+        """Get the Pydantic core schema for this type."""
+
+        def validate_tensor(
+            tensor: DLtypeTensorT, info: ValidationInfo
+        ) -> DLtypeTensorT:
+            """Validate the tensor."""
+            __tracebackhide__ = not _constants.DEBUG_MODE
+            self.check(tensor)
+
+            if _constants.PYDANTIC_INFO_KEY not in info.data:
+                info.data[_constants.PYDANTIC_INFO_KEY] = (
+                    _dltype_context.DLTypeContext()
+                )
+
+            dl_context = typing.cast(
+                "_dltype_context.DLTypeContext", info.data[_constants.PYDANTIC_INFO_KEY]
+            )
+            dl_context.add(info.field_name or "_unknown_", tensor, self)
+            dl_context.assert_context()
+
+            return tensor
+
+        if _deps.is_numpy_available() and typing.get_origin(source_type) is np.ndarray:
+            dtypes = _resolve_numpy_dtype(source_type)
+            if self.DTYPES and any(dtype not in self.DTYPES for dtype in dtypes):
+                msg = f"Invalid numpy array dtype=<{dtypes}> expected ({'|'.join(map(str, self.DTYPES))})"
+                raise _errors.DLTypeDtypeError(msg)
+            # numpy arrays don't implement isinstance() because the type is actually a
+            # parameterized generic alias and not a concrete type. We need to check the origin instead.
+            # This is a bit of a hack, but we still get the correct type hint in the end because we check against the dtype of the tensor first.
+            source_type = np.ndarray
+
+        return core_schema.with_info_after_validator_function(
+            validate_tensor,
+            schema=core_schema.is_instance_schema(source_type),
+            field_name=handler.field_name,
+        )
+
+    def check(self, tensor: DLtypeTensorT) -> None:
+        """Check if the tensor matches this type."""
+        # Basic validation for multi-axis dimensions
+        __tracebackhide__ = not _constants.DEBUG_MODE
+        if self.multiaxis_index is not None:
+            # Min required dimensions = expected shape length + extra dimensions - 1 (the multi-axis placeholder)
+            min_required_dims = len(self.expected_shape) - 1
+            if len(tensor.shape) < min_required_dims:
+                msg = f"Invalid number of dimensions: {tensor.shape=}, expected at least {min_required_dims}"
+                raise _errors.DLTypeShapeError(msg)
+
+        # Standard case: exact dimension count match
+        elif len(tensor.shape) != len(self.expected_shape):
+            msg = f"Invalid number of dimensions {tensor.shape=} {self.expected_shape=}"
+            raise _errors.DLTypeShapeError(msg)
+
+        if self.DTYPES and tensor.dtype not in self.DTYPES:
+            msg = f"Invalid dtype {tensor.dtype} expected {self.DTYPES}"
+            raise _errors.DLTypeDtypeError(msg)
+
+        for idx, dim in self._literal_dims:
+            # Adjust index if multiaxis exists and is before this dimension
+            adjusted_idx = idx
+            if self.multiaxis_index is not None and idx > self.multiaxis_index:
+                # Adjust by the difference between actual and expected dimensions
+                adjusted_idx += len(tensor.shape) - len(self.expected_shape)
+
+            if tensor.shape[adjusted_idx] != dim:
+                msg = f"[tensor=tensor] Invalid shape at dim_idx={adjusted_idx} actual={tensor.shape[adjusted_idx]} expected {dim}"
+                raise _errors.DLTypeShapeError(msg)

--- a/dltype/_lib/_tensor_type_base.py
+++ b/dltype/_lib/_tensor_type_base.py
@@ -4,9 +4,6 @@ from __future__ import annotations
 
 import typing
 
-import numpy as np
-import numpy.typing as npt
-import torch
 from pydantic_core import core_schema
 from typing_extensions import override
 
@@ -23,6 +20,7 @@ if typing.TYPE_CHECKING:
 
 if _deps.is_numpy_available() and _deps.is_torch_available():
     import torch
+    import numpy as np
     import numpy.typing as npt
 
     DLtypeTensorT: typing.TypeAlias = torch.Tensor | npt.NDArray[typing.Any]

--- a/dltype/_lib/_torch_tensors.py
+++ b/dltype/_lib/_torch_tensors.py
@@ -1,0 +1,37 @@
+"""Torch tensors for DLType."""
+
+import torch
+
+from dltype._lib._tensor_type_base import TensorTypeBase
+
+
+class IntTensor(TensorTypeBase):
+    """A class to represent an integer tensor type."""
+
+    DTYPES = (torch.int, torch.int8, torch.int16, torch.int32, torch.int64)
+
+
+class FloatTensor(TensorTypeBase):
+    """A class to represent a float tensor type."""
+
+    DTYPES = (
+        torch.float,
+        torch.float16,
+        torch.float32,
+        torch.float64,
+        torch.half,
+        torch.bfloat16,
+        torch.double,
+    )
+
+
+class BoolTensor(TensorTypeBase):
+    """A class to represent a boolean tensor type."""
+
+    DTYPES = (torch.bool,)
+
+
+class DoubleTensor(TensorTypeBase):
+    """A class to represent a double tensor type."""
+
+    DTYPES = (torch.double, torch.float64)

--- a/dltype/_lib/_universal_tensors.py
+++ b/dltype/_lib/_universal_tensors.py
@@ -1,0 +1,96 @@
+"""Tensor types work with either torch or numpy (maybe extended later)."""
+
+from dltype._lib import _tensor_type_base
+from dltype._lib._dependency_utilities import (
+    is_torch_available,
+    is_numpy_available,
+    raise_for_missing_dependency,
+)
+
+if is_numpy_available():
+    from dltype._lib._numpy_tensors import (
+        IntTensor as NumPyIntTensor,
+        FloatTensor as NumPyFloatTensor,
+        BoolTensor as NumPyBoolTensor,
+        DoubleTensor as NumPyDoubleTensor,
+    )
+
+if is_torch_available():
+    from dltype._lib._torch_tensors import (
+        IntTensor as TorchIntTensor,
+        FloatTensor as TorchFloatTensor,
+        BoolTensor as TorchBoolTensor,
+        DoubleTensor as TorchDoubleTensor,
+    )
+
+
+class IntTensor(_tensor_type_base.TensorTypeBase):
+    """A class to represent an integer tensor type."""
+
+    DTYPES = (
+        (*TorchIntTensor.DTYPES, *NumPyIntTensor.DTYPES)
+        if is_torch_available() and is_numpy_available()
+        else (
+            TorchIntTensor.DTYPES
+            if is_torch_available()
+            else NumPyIntTensor.DTYPES
+            if is_numpy_available()
+            else raise_for_missing_dependency()
+        )
+    )
+
+
+class FloatTensor(_tensor_type_base.TensorTypeBase):
+    """A class to represent a float tensor type."""
+
+    DTYPES = (
+        (*TorchFloatTensor.DTYPES, *NumPyFloatTensor.DTYPES)
+        if is_torch_available() and is_numpy_available()
+        else (
+            TorchFloatTensor.DTYPES
+            if is_torch_available()
+            else NumPyFloatTensor.DTYPES
+            if is_numpy_available()
+            else raise_for_missing_dependency()
+        )
+    )
+
+
+class BoolTensor(_tensor_type_base.TensorTypeBase):
+    """A class to represent a boolean tensor type."""
+
+    DTYPES = (
+        (*TorchBoolTensor.DTYPES, *NumPyBoolTensor.DTYPES)
+        if is_torch_available() and is_numpy_available()
+        else (
+            TorchBoolTensor.DTYPES
+            if is_torch_available()
+            else NumPyBoolTensor.DTYPES
+            if is_numpy_available()
+            else raise_for_missing_dependency()
+        )
+    )
+
+
+class DoubleTensor(_tensor_type_base.TensorTypeBase):
+    """A class to represent a double tensor type."""
+
+    DTYPES = (
+        (*TorchDoubleTensor.DTYPES, *NumPyDoubleTensor.DTYPES)
+        if is_torch_available() and is_numpy_available()
+        else (
+            TorchDoubleTensor.DTYPES
+            if is_torch_available()
+            else NumPyDoubleTensor.DTYPES
+            if is_numpy_available()
+            else raise_for_missing_dependency()
+        )
+    )
+
+
+__all__ = [
+    "IntTensor",
+    "FloatTensor",
+    "BoolTensor",
+    "DoubleTensor",
+]

--- a/dltype/tests/dltype_test.py
+++ b/dltype/tests/dltype_test.py
@@ -945,10 +945,7 @@ def test_named_axis() -> None:
 
 # mock max_acceptable_eval_time to zero to ensure we issue a warning if the context takes too long
 def test_warn_on_function_evaluation() -> None:
-    with patch(
-        "dltype._lib._core._maybe_warn_runtime",
-        return_value=True,
-    ):
+    with patch("dltype._lib._dltype_context._maybe_warn_runtime", return_value=True):
 
         @dltype.dltyped()
         def dummy_function(

--- a/dltype/tests/interop_test.py
+++ b/dltype/tests/interop_test.py
@@ -1,0 +1,89 @@
+"""Test that dltype can operate with either numpy or torch installed."""
+
+import pytest
+
+from unittest.mock import patch
+from importlib import reload
+from collections.abc import Iterator
+import dltype
+import sys
+
+import numpy
+import torch
+
+
+@pytest.fixture(autouse=True)
+def clear_cached_available_fns() -> Iterator[None]:
+    """Clear cached functions to ensure fresh imports."""
+    # Clear the cache for the dependency utilities
+    from dltype._lib._dependency_utilities import is_torch_available, is_numpy_available
+
+    is_torch_available.cache_clear()
+    is_numpy_available.cache_clear()
+    yield
+
+
+@pytest.fixture(autouse=True)
+def reset_modules() -> Iterator[None]:
+    # Store a copy of the initial sys.modules state
+    initial_modules = sys.modules.copy()
+    yield
+    # Restore sys.modules to its initial state after the test
+    sys.modules.clear()
+    sys.modules.update(initial_modules)
+
+
+@pytest.fixture()
+def mock_missing_numpy() -> Iterator[None]:
+    """Mock numpy as missing."""
+    with patch("dltype._lib._dependency_utilities.np", None):
+        yield
+
+
+@pytest.fixture()
+def mock_missing_torch() -> Iterator[None]:
+    """Mock torch as missing."""
+    with patch("dltype._lib._dependency_utilities.torch", None):
+        yield
+
+
+def test_dltype_imports_without_torch(mock_missing_torch: None):
+    """Test that dltype can be imported without torch."""
+    del sys.modules["torch"]
+
+    with pytest.raises(ImportError):
+        reload(torch)
+
+    _reloaded_dltype = reload(dltype)
+
+    assert _reloaded_dltype.BoolTensor.DTYPES == (numpy.bool_,)
+
+
+def test_dltype_imports_without_numpy(mock_missing_numpy: None):
+    """Test that dltype can be imported without numpy."""
+    del sys.modules["numpy"]
+
+    with pytest.raises(ImportError):
+        reload(numpy)
+
+    _reloaded_dltype = reload(dltype)
+
+    assert _reloaded_dltype.BoolTensor.DTYPES == (torch.bool,)
+
+
+def test_dltype_imports_with_both():
+    """Test that dltype can be imported with both torch and numpy."""
+    _reloaded_dltype = reload(dltype)
+    assert _reloaded_dltype.BoolTensor.DTYPES == (
+        torch.bool,
+        numpy.bool_,
+    )
+
+
+def test_dltype_asserts_import_error_with_neither(
+    mock_missing_numpy: None, mock_missing_torch: None
+):
+    """Test that dltype raises ImportError if neither torch nor numpy is available."""
+
+    with pytest.raises(ImportError, match="Neither torch nor numpy is available"):
+        reload(dltype)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,11 +10,11 @@ dev = [
 dependencies = [
   "pydantic>=2.0"
 ]
-description = "Add your description here"
+description = "An extremely lightweight typing library for torch tensors or numpy arrays. Supports runtime shape checking and data type validation."
 name = "dltype"
 readme = "README.md"
 requires-python = ">=3.10"
-version = "0.1.0"
+version = "0.2.0"
 
 [project.optional-dependencies]
 numpy = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,12 +8,18 @@ dev = [
 
 [project]
 dependencies = [
-  "numpy",
-  "pydantic>=2.0",
-  "torch>=1.4.0"
+  "pydantic>=2.0"
 ]
 description = "Add your description here"
 name = "dltype"
 readme = "README.md"
 requires-python = ">=3.10"
 version = "0.1.0"
+
+[project.optional-dependencies]
+numpy = [
+  "numpy"
+]
+torch = [
+  "torch>=1.4.0"
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,11 @@
 [dependency-groups]
 dev = [
+  "numpy>=2.2.6",
   "onnx>=1.18.0",
   "pre-commit>=4.2.0",
   "pytest>=8.4.1",
-  "ruff>=0.12.0"
+  "ruff>=0.12.0",
+  "torch>=1.4.0"
 ]
 
 [project]

--- a/uv.lock
+++ b/uv.lock
@@ -62,10 +62,13 @@ torch = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.3.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "onnx" },
     { name = "pre-commit" },
     { name = "pytest" },
     { name = "ruff" },
+    { name = "torch" },
 ]
 
 [package.metadata]
@@ -78,10 +81,12 @@ provides-extras = ["numpy", "torch"]
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "numpy", specifier = ">=2.2.6" },
     { name = "onnx", specifier = ">=1.18.0" },
     { name = "pre-commit", specifier = ">=4.2.0" },
     { name = "pytest", specifier = ">=8.4.1" },
     { name = "ruff", specifier = ">=0.12.0" },
+    { name = "torch", specifier = ">=1.4.0" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -48,9 +48,15 @@ name = "dltype"
 version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
+    { name = "pydantic" },
+]
+
+[package.optional-dependencies]
+numpy = [
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "numpy", version = "2.3.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "pydantic" },
+]
+torch = [
     { name = "torch" },
 ]
 
@@ -64,10 +70,11 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "numpy" },
+    { name = "numpy", marker = "extra == 'numpy'" },
     { name = "pydantic", specifier = ">=2.0" },
-    { name = "torch", specifier = ">=1.4.0" },
+    { name = "torch", marker = "extra == 'torch'", specifier = ">=1.4.0" },
 ]
+provides-extras = ["torch", "numpy"]
 
 [package.metadata.requires-dev]
 dev = [

--- a/uv.lock
+++ b/uv.lock
@@ -45,7 +45,7 @@ wheels = [
 
 [[package]]
 name = "dltype"
-version = "0.1.0"
+version = "0.2.0"
 source = { virtual = "." }
 dependencies = [
     { name = "pydantic" },
@@ -74,7 +74,7 @@ requires-dist = [
     { name = "pydantic", specifier = ">=2.0" },
     { name = "torch", marker = "extra == 'torch'", specifier = ">=1.4.0" },
 ]
-provides-extras = ["torch", "numpy"]
+provides-extras = ["numpy", "torch"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
# Description

- What is this PR doing and why?
Speeds up installation time drastically by removing the explicit dependency on torch and numpy. 
Users may install either and still use the library.

## Testing

Please select all that apply.

- [x] Existing unit tests
- [x] Unit tests added by this PR
- [ ] Other (please explain)
- [ ] This PR is not tested

## Test instructions

- Please add relevant commands required to reproduce the testing described above
- Please add relevant test outputs (screenshots, logs, etc.)
