### PR TITLE
Enable symbolic shapes to be used instead of strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,13 @@ FloatTensor["... channels h w"] # anonymous dimension will not be matched across
 DoubleTensor["batch *channels features"] # named dimension which can be matched across tensors
 ```
 
+### Statically Defined Shapes
+
+```python
+Shape[AnonymouousAxis("batch"), ConstantAxis("rgb", 3), VariableAxis("imgh"), VariableAxis("imgw")]
+Shape[..., VariableAxis("N"), 4]
+```
+
 ## Argument and return typing
 
 ```python

--- a/dltype/__init__.py
+++ b/dltype/__init__.py
@@ -26,6 +26,15 @@ from dltype._lib._errors import (
     DLTypeShapeError,
     DLTypeUnsupportedTensorTypeError,
 )
+from dltype._lib._symbolic_expressions import (
+    AnonymousAxis,
+    ConstantAxis,
+    LiteralAxis,
+    Max,
+    Min,
+    Shape,
+    VariableAxis,
+)
 from dltype._lib._tensor_type_base import (
     TensorTypeBase,
 )
@@ -105,9 +114,11 @@ __all__ = [
     "DEBUG_MODE",
     "MAX_ACCEPTABLE_EVALUATION_TIME_NS",
     "SUPPORTED_TENSOR_TYPES",
+    "AnonymousAxis",
     "BFloat16Tensor",
     "BFloat16Tensor",
     "BoolTensor",
+    "ConstantAxis",
     "DLTypeDtypeError",
     "DLTypeDuplicateError",
     "DLTypeError",
@@ -128,6 +139,10 @@ __all__ = [
     "Int32Tensor",
     "Int64Tensor",
     "IntTensor",
+    "LiteralAxis",
+    "Max",
+    "Min",
+    "Shape",
     "SignedIntTensor",
     "TensorTypeBase",
     "UInt8Tensor",
@@ -135,6 +150,7 @@ __all__ = [
     "UInt32Tensor",
     "UInt64Tensor",
     "UnsignedIntTensor",
+    "VariableAxis",
     "dltyped",
     "dltyped_dataclass",
     "dltyped_namedtuple",

--- a/dltype/_lib/_symbolic_expressions.py
+++ b/dltype/_lib/_symbolic_expressions.py
@@ -1,0 +1,228 @@
+"""Allows specifying expressions as symbolic types rather than strings."""
+
+from __future__ import annotations
+
+import typing
+from abc import ABC, abstractmethod
+from types import EllipsisType
+
+from typing_extensions import override
+
+
+class AxisOperationBase(ABC):
+    def __init__(
+        self,
+        lhs: OperableAxis | ComputedAxis | int,
+        rhs: OperableAxis | ComputedAxis | int,
+    ) -> None:
+        self._lhs = lhs if isinstance(lhs, OperableAxis | ComputedAxis) else LiteralAxis(lhs)
+        self._rhs = rhs if isinstance(rhs, OperableAxis | ComputedAxis) else LiteralAxis(rhs)
+
+    @abstractmethod
+    def __str__(self) -> str:
+        pass
+
+    def __repr__(self) -> str:
+        return self.__str__()
+
+
+class Add(AxisOperationBase):
+    def __str__(self) -> str:
+        if isinstance(self._lhs, LiteralAxis) and isinstance(self._rhs, LiteralAxis):
+            return f"{self._lhs.value + self._rhs.value}"
+        return f"{self._lhs}+{self._rhs}"
+
+
+class Subtract(AxisOperationBase):
+    def __str__(self) -> str:
+        if isinstance(self._lhs, LiteralAxis) and isinstance(self._rhs, LiteralAxis):
+            return f"{self._lhs.value - self._rhs.value}"
+        return f"{self._lhs}-{self._rhs}"
+
+
+class Divide(AxisOperationBase):
+    def __str__(self) -> str:
+        if isinstance(self._lhs, LiteralAxis) and isinstance(self._rhs, LiteralAxis):
+            return f"{self._lhs.value // self._rhs.value}"
+        return f"{self._lhs}/{self._rhs}"
+
+
+class Multiply(AxisOperationBase):
+    def __str__(self) -> str:
+        if isinstance(self._lhs, LiteralAxis) and isinstance(self._rhs, LiteralAxis):
+            return f"{self._lhs.value * self._rhs.value}"
+        return f"{self._lhs}*{self._rhs}"
+
+
+class Exp(AxisOperationBase):
+    def __str__(self) -> str:
+        if isinstance(self._lhs, LiteralAxis) and isinstance(self._rhs, LiteralAxis):
+            return f"{self._lhs.value**self._rhs.value}"
+        return f"{self._lhs}^{self._rhs}"
+
+
+class Max(AxisOperationBase):
+    def __str__(self) -> str:
+        if isinstance(self._lhs, LiteralAxis) and isinstance(self._rhs, LiteralAxis):
+            return f"{max(self._lhs.value, self._rhs.value)}"
+        return f"max({self._lhs},{self._rhs})"
+
+
+class Min(AxisOperationBase):
+    def __str__(self) -> str:
+        if isinstance(self._lhs, LiteralAxis) and isinstance(self._rhs, LiteralAxis):
+            return f"{min(self._lhs.value, self._rhs.value)}"
+        return f"min({self._lhs},{self._rhs})"
+
+
+class OperableAxis(ABC):
+    @abstractmethod
+    def __str__(self) -> str: ...
+
+    def __repr__(self) -> str:
+        return self.__str__()
+
+    def __resolve_expr_sides(
+        self,
+        other: OperableAxisT,
+        *,
+        reverse: bool = False,
+    ) -> tuple[OperableAxisT | OperableAxis, OperableAxisT | OperableAxis]:
+        lhs = other if reverse else self
+        rhs = self if reverse else other
+
+        return lhs, rhs
+
+    def __add__(self, other: OperableAxisT) -> ComputedAxis:
+        return ComputedAxis(Add(*self.__resolve_expr_sides(other)))
+
+    def __radd__(self, other: OperableAxisT) -> ComputedAxis:
+        return ComputedAxis(Add(*self.__resolve_expr_sides(other, reverse=True)))
+
+    def __sub__(self, other: OperableAxisT) -> ComputedAxis:
+        return ComputedAxis(Subtract(*self.__resolve_expr_sides(other)))
+
+    def __rsub__(self, other: OperableAxisT) -> ComputedAxis:
+        return ComputedAxis(Subtract(*self.__resolve_expr_sides(other, reverse=True)))
+
+    def __mul__(self, other: OperableAxisT) -> ComputedAxis:
+        return ComputedAxis(Multiply(*self.__resolve_expr_sides(other)))
+
+    def __rmul__(self, other: OperableAxisT) -> ComputedAxis:
+        return ComputedAxis(Multiply(*self.__resolve_expr_sides(other, reverse=True)))
+
+    def __floordiv__(self, other: OperableAxisT) -> ComputedAxis:
+        return ComputedAxis(Divide(*self.__resolve_expr_sides(other)))
+
+    def __rfloordiv__(self, other: OperableAxisT) -> ComputedAxis:
+        return ComputedAxis(Divide(*self.__resolve_expr_sides(other, reverse=True)))
+
+    def __pow__(self, other: OperableAxisT) -> ComputedAxis:
+        return ComputedAxis(Exp(*self.__resolve_expr_sides(other)))
+
+    def __rpow__(self, other: OperableAxisT) -> ComputedAxis:
+        return ComputedAxis(Exp(*self.__resolve_expr_sides(other, reverse=True)))
+
+
+class LiteralAxis(OperableAxis):
+    def __init__(self, value: int) -> None:
+        """Initialize an axis with a literal integer value."""
+        self._value = value
+
+    @property
+    def value(self) -> int:
+        return self._value
+
+    def __str__(self) -> str:
+        return str(self._value)
+
+
+class VariableAxis(OperableAxis):
+    def __init__(self, identifier: str) -> None:
+        """Initialize an axis with an identifier string."""
+        self._identifier = identifier
+
+    def __str__(self) -> str:
+        return str(self._identifier)
+
+
+class ComputedAxis(OperableAxis):
+    def __init__(self, computation: AxisOperationBase) -> None:
+        self._computation = computation
+
+    def __str__(self) -> str:
+        return f"{self._computation}"
+
+    def __repr__(self) -> str:
+        return self.__str__()
+
+
+class NamedComputedAxis(ComputedAxis):
+    def __init__(self, identifier: str, computation: AxisOperationBase) -> None:
+        super().__init__(computation)
+        self._identifier = identifier
+
+    @property
+    def identifier(self) -> str:
+        return self._identifier
+
+    @override
+    def __str__(self) -> str:
+        return f"{self._identifier}={self._computation}"
+
+
+OperableAxisT: typing.TypeAlias = LiteralAxis | VariableAxis | ComputedAxis | int
+
+
+class ConstantAxis:
+    def __init__(self, identifier: str, value: int) -> None:
+        """Initialize a symbol with an identifier string equal to a constant value i.e. batch=3."""
+        self._identifier = str(identifier)
+        self._value = value
+
+    @property
+    def value(self) -> int:
+        return self._value
+
+    @property
+    def identifier(self) -> str:
+        return self._identifier
+
+    def __str__(self) -> str:
+        return f"{self._identifier}={self._value}"
+
+
+class AnonymousAxis:
+    def __init__(self, maybe_name: str | EllipsisType) -> None:
+        """Initialize an axis or set of axes with zero or more values, optionally give a name."""
+        self._identifier = maybe_name
+
+    def __str__(self) -> str:
+        return ("*" + str(self._identifier)) if isinstance(self._identifier, str) else "..."
+
+    def __repr__(self) -> str:
+        return self.__str__()
+
+
+AxisT: typing.TypeAlias = OperableAxisT | AnonymousAxis | ConstantAxis
+ExpressionComponentT = AxisT | EllipsisType
+
+
+class Shape:
+    """The expression of tensor shape as a sequence of expressions."""
+
+    def __init__(self, symbols: tuple[ExpressionComponentT, ...] | ExpressionComponentT) -> None:
+        _symbols = symbols if isinstance(symbols, tuple) else (symbols,)
+        self._raveled_expressions = [
+            (AnonymousAxis(...) if isinstance(symbol, EllipsisType) else symbol) for symbol in _symbols
+        ]
+
+    def __str__(self) -> str:
+        return " ".join(map(str, self._raveled_expressions))
+
+    def __repr__(self) -> str:
+        return self.__str__()
+
+    @classmethod
+    def __class_getitem__(cls, args: tuple[ExpressionComponentT, ...]) -> Shape:
+        return cls(args)

--- a/dltype/_lib/_tensor_type_base.py
+++ b/dltype/_lib/_tensor_type_base.py
@@ -13,6 +13,7 @@ from dltype._lib import (
     _dtypes,
     _errors,
     _parser,
+    _symbolic_expressions,
 )
 from dltype._lib import (
     _dependency_utilities as _deps,
@@ -116,9 +117,9 @@ class TensorTypeBase:
         return tuple(processed_shapes)
 
     @classmethod
-    def __class_getitem__(cls, shape_string: str) -> TensorTypeBase:
+    def __class_getitem__(cls, shape_string: str | None | _symbolic_expressions.Shape) -> TensorTypeBase:
         """Get the type of the tensor."""
-        return cls(shape_string)
+        return cls(shape_string if isinstance(shape_string, str | None) else str(shape_string))
 
     def __get_pydantic_core_schema__(
         self,

--- a/dltype/tests/parser_test.py
+++ b/dltype/tests/parser_test.py
@@ -3,6 +3,7 @@
 
 import pytest
 
+from dltype import AnonymousAxis, ConstantAxis, LiteralAxis, Max, Min, Shape, VariableAxis
 from dltype._lib import _parser
 
 
@@ -56,3 +57,49 @@ def test_parse_expression(
 def test_parse_invalid_expression(expression: str, scope: dict[str, int]) -> None:
     with pytest.raises((SyntaxError, KeyError)):
         _parser.expression_from_string(expression).evaluate(scope)
+
+
+@pytest.mark.parametrize(
+    ("expression", "expected"),
+    [
+        (Shape[1 + 2], "3"),
+        (Shape[Max(1, VariableAxis("imageh"))], "max(1,imageh)"),
+        (Shape[Min(1, 2)], "1"),
+        (Shape[ConstantAxis("RGB", 4)], "RGB=4"),
+        (Shape[..., VariableAxis("c"), VariableAxis("h"), VariableAxis("w")], "... c h w"),
+        (
+            Shape[AnonymousAxis("batch"), VariableAxis("c"), VariableAxis("h"), VariableAxis("w")],
+            "*batch c h w",
+        ),
+        (Shape[LiteralAxis(4), VariableAxis("r")], "4 r"),
+        (Shape[Min(4 + VariableAxis("image_w"), VariableAxis("imageh"))], "min(4+image_w,imageh)"),
+    ],
+)
+def test_parse_symbolic(expression: Shape, expected: str) -> None:
+    assert str(expression) == expected
+
+
+def test_raises() -> None:
+    rgb = ConstantAxis("RGB", 3)
+
+    # NOTE: we disallow adding anything to constants because it isn't clear what the intent
+    # would be.
+
+    # For example, if we have rgb=3 we clearly have an axis that is meant for
+    # rgb channels and would have a shape of 3.
+
+    # however, what does rgb+1 mean? Do we want the axis of rgb to be 4 instead? in which case, is it even
+    # referring to the same axis anymore? Or do we want a new axis for rgba, but how do we change the name in an addition operation?
+
+    with pytest.raises(TypeError):
+        _ = rgb + 4  # pyright: ignore[reportUnknownVariableType, reportOperatorIssue]
+
+    with pytest.raises(TypeError):
+        _ = 4 + rgb  # pyright: ignore[reportUnknownVariableType, reportOperatorIssue]
+
+    # Similarly operating on anonymous axes doesn't make sense in general as it isn't clear what the intent would be
+    with pytest.raises(TypeError):
+        _ = AnonymousAxis("*batch") + 4  # pyright: ignore[reportUnknownVariableType, reportOperatorIssue]
+
+    with pytest.raises(TypeError):
+        _ = 4 + AnonymousAxis("*batch")  # pyright: ignore[reportUnknownVariableType, reportOperatorIssue]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ dev = [
   "ruff>=0.12.0",
   "torch>=1.4.0",
   "setuptools>=60.0.0",
-  "pyright>=1.1.405"
+  "pyright>=1.1.407"
 ]
 
 [project]
@@ -18,7 +18,7 @@ license-files = ["LICENSE"]
 name = "dltype"
 readme = "README.md"
 requires-python = ">=3.10"
-version = "0.5.2"
+version = "0.6.0"
 
 [project.optional-dependencies]
 numpy = ["numpy"]

--- a/uv.lock
+++ b/uv.lock
@@ -27,7 +27,7 @@ wheels = [
 
 [[package]]
 name = "dltype"
-version = "0.5.2"
+version = "0.6.0"
 source = { virtual = "." }
 dependencies = [
     { name = "pydantic" },
@@ -66,7 +66,7 @@ provides-extras = ["numpy", "torch"]
 dev = [
     { name = "numpy", specifier = ">=2.2.6" },
     { name = "onnx", specifier = ">=1.18.0" },
-    { name = "pyright", specifier = ">=1.1.405" },
+    { name = "pyright", specifier = ">=1.1.407" },
     { name = "pytest", specifier = ">=8.4.1" },
     { name = "ruff", specifier = ">=0.12.0" },
     { name = "setuptools", specifier = ">=60.0.0" },
@@ -669,15 +669,15 @@ wheels = [
 
 [[package]]
 name = "pyright"
-version = "1.1.405"
+version = "1.1.407"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "nodeenv" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/fb/6c/ba4bbee22e76af700ea593a1d8701e3225080956753bee9750dcc25e2649/pyright-1.1.405.tar.gz", hash = "sha256:5c2a30e1037af27eb463a1cc0b9f6d65fec48478ccf092c1ac28385a15c55763", size = 4068319, upload-time = "2025-09-04T03:37:06.776Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a6/1b/0aa08ee42948b61745ac5b5b5ccaec4669e8884b53d31c8ec20b2fcd6b6f/pyright-1.1.407.tar.gz", hash = "sha256:099674dba5c10489832d4a4b2d302636152a9a42d317986c38474c76fe562262", size = 4122872, upload-time = "2025-10-24T23:17:15.145Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d5/1a/524f832e1ff1962a22a1accc775ca7b143ba2e9f5924bb6749dce566784a/pyright-1.1.405-py3-none-any.whl", hash = "sha256:a2cb13700b5508ce8e5d4546034cb7ea4aedb60215c6c33f56cec7f53996035a", size = 5905038, upload-time = "2025-09-04T03:37:04.913Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/93/b69052907d032b00c40cb656d21438ec00b3a471733de137a3f65a49a0a0/pyright-1.1.407-py3-none-any.whl", hash = "sha256:6dd419f54fcc13f03b52285796d65e639786373f433e243f8b94cf93a7444d21", size = 5997008, upload-time = "2025-10-24T23:17:13.159Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
# Description

This enables a layer of static type checking to dltyped functions based on the expression. 

Notably, it catches errors in expressions statically rather than having them be errors at import time when the expression is normally parsed. We are adopting an incremental approach to this by first compiling the expression down to a parse-able expression, but in the future we may adopt these structures as the core elements of the expression parser to reduce duplication and increase expressiveness.

Addresses #21

## Testing

Please select all that apply.

- [x] Existing unit tests
- [x] Unit tests added by this PR
- [ ] Other (please explain)
- [ ] This PR is not tested

## Test instructions

Unit tests cover all new functionality.
