### PR TITLE
fix type as an arg causing an error

### DIFF
--- a/dltype/_lib/_core.py
+++ b/dltype/_lib/_core.py
@@ -101,7 +101,7 @@ class DLTypeAnnotation(NamedTuple):
         if origin is not Annotated:
             if (
                 any(T in hint.mro() for T in _dtypes.SUPPORTED_TENSOR_TYPES)
-                if hint and hasattr(hint, "mro")
+                if hint and hasattr(hint, "mro") and hint is not type
                 else False
             ):
                 warnings.warn(

--- a/dltype/tests/dltype_test.py
+++ b/dltype/tests/dltype_test.py
@@ -1732,3 +1732,11 @@ def test_aliased_optional() -> None:
 
     with pytest.raises(dltype.DLTypeUnsupportedTensorTypeError):
         func(None, torch.zeros((1, 2, 3)))  # pyright: ignore[reportArgumentType]
+
+
+def test_weird_type() -> None:
+    @dltype.dltyped()
+    def func(arg: type) -> None:
+        pass
+
+    func(int)


### PR DESCRIPTION
# Description

Fixes a hard to catch issue where a type needs an argument to mro and thus causes an error

## Testing

Please select all that apply.

- [ ] Existing unit tests
- [x] Unit tests added by this PR
- [ ] Other (please explain)
- [ ] This PR is not tested

## Test instructions

- Please add relevant commands required to reproduce the testing described above
- Please add relevant test outputs (screenshots, logs, etc.)
